### PR TITLE
Fix NPE during plugin disable

### DIFF
--- a/src/main/java/dev/rusthero/mmobazaar/MMOBazaar.java
+++ b/src/main/java/dev/rusthero/mmobazaar/MMOBazaar.java
@@ -18,7 +18,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -93,12 +92,15 @@ public class MMOBazaar extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        // Close all GUIs in case it is a reload to prevent item dupe. Rare but dangerous one
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            Inventory openInv = player.getOpenInventory().getTopInventory();
-            if (context.guiSessions.getOwnerGUI(player.getUniqueId()).isPresent() || context.guiSessions.getConfirmingGUI(player.getUniqueId()).isPresent() || context.guiSessions.getCustomerGUI(player.getUniqueId()).isPresent()) {
-                player.closeInventory();
-                player.sendMessage("§cBazaar GUI was forcibly closed due to reload.");
+        if (this.context != null) {
+            // Close all GUIs in case it is a reload to prevent item dupe. Rare but dangerous one
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (context.guiSessions.getOwnerGUI(player.getUniqueId()).isPresent()
+                        || context.guiSessions.getConfirmingGUI(player.getUniqueId()).isPresent()
+                        || context.guiSessions.getCustomerGUI(player.getUniqueId()).isPresent()) {
+                    player.closeInventory();
+                    player.sendMessage("§cBazaar GUI was forcibly closed due to reload.");
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid NullPointerException in `onDisable` when plugin failed to start

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68432895bf188328b9985fd2aeae9163