### PR TITLE
Fix SQLite config subsection usage

### DIFF
--- a/src/main/java/dev/rusthero/mmobazaar/config/StorageConfig.java
+++ b/src/main/java/dev/rusthero/mmobazaar/config/StorageConfig.java
@@ -44,6 +44,7 @@ public class StorageConfig {
     }
 
     public @NotNull HikariConfig getHikariConfig() {
+        var section = getSubSection();
         if (engine == SQLITE) {
             plugin.getDataFolder().mkdirs();
             String filePath = section.getString("file", "data.db");
@@ -56,7 +57,6 @@ public class StorageConfig {
             return hikari;
         }
 
-        var section = getSubSection();
         String host = section.getString("host", "localhost");
         String database = section.getString("database", "mmobazaar");
         String user = section.getString("username", "root");


### PR DESCRIPTION
## Summary
- fetch the SQLite configuration subsection once and reuse it across code paths

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network unreachable)*
- `mvn -q package` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68432b98baa48328a1809ef0a00ff669