### PR TITLE
Fix comment and simplify meta handling

### DIFF
--- a/src/main/java/dev/rusthero/mmobazaar/gui/ConfirmPurchaseGUI.java
+++ b/src/main/java/dev/rusthero/mmobazaar/gui/ConfirmPurchaseGUI.java
@@ -57,12 +57,8 @@ public class ConfirmPurchaseGUI {
             lore.add("§eClick to confirm purchase");
             pMeta.setLore(lore);
 
-            // Only set name if already exists
-            if (pMeta.hasDisplayName()) {
-                preview.setItemMeta(pMeta);
-            } else {
-                preview.setItemMeta(pMeta);
-            }
+            // Apply the customized meta to the preview item
+            preview.setItemMeta(pMeta);
         }
         gui.setItem(4, preview);
 


### PR DESCRIPTION
## Summary
- update misleading comment in `ConfirmPurchaseGUI`
- set preview meta without redundant conditional

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68432bc0bc88832884c24da52a4a084c